### PR TITLE
Add collections screen with subject based navigation

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,57 +1,75 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Link } from 'expo-router';
-import { useState } from 'react';
+import { Link, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useState } from 'react';
 import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Header from '../components/layout/Header';
-import SubjectCard from '../components/ui/SubjectCard';
 import { StatsCard } from '../components/ui/StatsCard';
+import SubjectCard from '../components/ui/SubjectCard';
+import { MOCK_SUBJECTS } from '../constants/mockData';
+
 export default function HomeScreen() {
-  const [subjects, setSubjects] = useState([]);
+  const [subjects, setSubjects] = useState(MOCK_SUBJECTS);
   const [newSubject, setNewSubject] = useState('');
   const [showInput, setShowInput] = useState(false);
 
   const addSubject = () => {
     if (newSubject.trim() !== '') {
-      setSubjects([...subjects, newSubject]);
+      const newSubjectData = {
+        id: Date.now().toString(),
+        name: newSubject.trim(),
+        icon: 'book',
+        iconBackgroundColor: '#E0F2FE',
+        headerColor: '#3B82F6',
+        collections: [],
+      };
+      setSubjects([...subjects, newSubjectData]);
       setNewSubject('');
       setShowInput(false);
     }
   };
 
-  const removeSubject = (subject) => {
-    setSubjects(subjects.filter((s) => s !== subject));
+  const removeSubject = (subjectId) => {
+    setSubjects(subjects.filter((s) => s.id !== subjectId));
+  };
+
+  const handleSubjectPress = (subject) => {
+    router.push(`/subjects/${subject.id}`);
   };
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <StatusBar style="light" backgroundColor="#007AFF" />
       <Header
-      title="Piqe-Hiqe"
-      subtitle="Your daily lessons"
-      rightButton={
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 15 }}>
-          <Link href="/profile" asChild>
-            <Pressable>
-              <Ionicons name="person-circle-outline" size={28} color="white" />
-            </Pressable>
-          </Link>
+        title="Piqe-Hiqe"
+        subtitle="Your daily lessons"
+        rightButton={
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 15 }}>
+            <Link href="/profile" asChild>
+              <Pressable>
+                <Ionicons name="person-circle-outline" size={28} color="white" />
+              </Pressable>
+            </Link>
 
-          <Pressable onPress={() => setShowInput(!showInput)}>
-            <Ionicons name="add" size={28} color="white" />
-          </Pressable>
-        </View>
-      }
-    />
+            <Pressable onPress={() => setShowInput(!showInput)}>
+              <Ionicons name="add" size={28} color="white" />
+            </Pressable>
+          </View>
+        }
+      />
       <View style={styles.container}>
-        
         <View style={styles.generalStatsContainer}>
-          
-            <StatsCard subject="12" easy={0} medium={0} hard={0} label="Day Streak" />
-            <StatsCard subject="245" easy={0} medium={0} hard={0} label="Cards Done" />
-            <StatsCard subject="6" easy={0} medium={0} hard={0} label="Subjects" />
-            </View>
+          <StatsCard subject="12" easy={0} medium={0} hard={0} label="Day Streak" />
+          <StatsCard subject="245" easy={0} medium={0} hard={0} label="Cards Done" />
+          <StatsCard
+            subject={subjects.length.toString()}
+            easy={0}
+            medium={0}
+            hard={0}
+            label="Subjects"
+          />
+        </View>
 
         <Text style={styles.title}>Your Subjects</Text>
 
@@ -71,16 +89,25 @@ export default function HomeScreen() {
 
         <FlatList
           data={subjects}
-          keyExtractor={(item, index) => index.toString()}
+          keyExtractor={(item) => item.id}
           numColumns={2}
           columnWrapperStyle={{ justifyContent: 'space-between', paddingHorizontal: 10 }}
           contentContainerStyle={{ paddingVertical: 10 }}
           renderItem={({ item }) => (
             <View style={{ marginBottom: 15 }}>
-              <SubjectCard subjectName={item} icon={require('../assets/images/flashcard.png')} iconBackgroundColor="#bcdee1ff" collectionCount={5}
-            />
-              <Pressable onPress={() => removeSubject(item)} style={{ marginTop: 4, alignSelf: 'flex-end' }}>
-                <Ionicons name="trash" size={22} color="green"  />
+              <Pressable onPress={() => handleSubjectPress(item)}>
+                <SubjectCard
+                  subjectName={item.name}
+                  icon={require('../assets/images/flashcard.png')}
+                  iconBackgroundColor={item.iconBackgroundColor}
+                  collectionCount={item.collections.length}
+                />
+              </Pressable>
+              <Pressable
+                onPress={() => removeSubject(item.id)}
+                style={{ marginTop: 4, alignSelf: 'flex-end' }}
+              >
+                <Ionicons name="trash" size={22} color="#EF4444" />
               </Pressable>
             </View>
           )}
@@ -96,10 +123,10 @@ export default function HomeScreen() {
                 <Text style={styles.linkText}>Subjects</Text>
               </Pressable>
             </Link>
-            
+
             <Link href="/progress" asChild>
               <Pressable style={styles.link}>
-                <Text style={styles.linkText}>Shiko Progresin</Text> 
+                <Text style={styles.linkText}>Shiko Progresin</Text>
               </Pressable>
             </Link>
           </View>
@@ -164,7 +191,7 @@ const styles = StyleSheet.create({
   generalStatsContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    paddingHorizontal: 5, 
+    paddingHorizontal: 5,
     width: '100%',
     marginBottom: 20,
   },
@@ -186,7 +213,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 24,
     borderRadius: 8,
-     width: '80%', 
+    width: '80%',
     alignItems: 'center',
   },
   linkText: {
@@ -194,7 +221,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-   list: {
+  list: {
     width: '100%',
     flexGrow: 1,
   },

--- a/app/subjects/[id].jsx
+++ b/app/subjects/[id].jsx
@@ -1,15 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
-import {
-  FlatList,
-  Modal,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View
-} from 'react-native';
+import { FlatList, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import CollectionCard from '../../components/ui/CollectionCard';
 import { getSubjectById } from '../../constants/mockData';
@@ -18,7 +10,7 @@ export default function SubjectCollectionsScreen() {
   const { id } = useLocalSearchParams();
   const subject = getSubjectById(id);
 
-  // State for collections (will be updated dynamically)
+  // State for collections
   const [collections, setCollections] = useState(subject?.collections || []);
   const [modalVisible, setModalVisible] = useState(false);
   const [newCollectionName, setNewCollectionName] = useState('');
@@ -106,10 +98,7 @@ export default function SubjectCollectionsScreen() {
         />
 
         {/* Add Collection Button */}
-        <Pressable
-          style={styles.addButton}
-          onPress={() => setModalVisible(true)}
-        >
+        <Pressable style={styles.addButton} onPress={() => setModalVisible(true)}>
           <Ionicons name="add" size={20} color="#4F46E5" />
           <Text style={styles.addButtonText}>Add Collection</Text>
         </Pressable>

--- a/components/ui/CollectionCard.jsx
+++ b/components/ui/CollectionCard.jsx
@@ -8,19 +8,12 @@ const CollectionCard = ({ collection, onPress, gradientColors }) => {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [
-        styles.card,
-        pressed && styles.cardPressed,
-      ]}
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
     >
       <View style={styles.content}>
         {/* Icon */}
         <View style={[styles.iconWrapper, isCompleted ? styles.iconCompleted : styles.iconDefault]}>
-          <Ionicons
-            name="folder-open"
-            size={24}
-            color={isCompleted ? '#059669' : '#4F46E5'}
-          />
+          <Ionicons name="folder-open" size={24} color={isCompleted ? '#059669' : '#4F46E5'} />
         </View>
 
         {/* Collection Info */}

--- a/constants/mockData.js
+++ b/constants/mockData.js
@@ -7,7 +7,7 @@ export const MOCK_SUBJECTS = [
     name: 'Mathematics',
     icon: 'calculator',
     iconBackgroundColor: '#E0F2FE',
-    headerColor: '#3B82F6', // blue
+    headerColor: '#3B82F6',
     collections: [
       { id: '1', name: 'Algebra Basics', cards: 45, completed: 32 },
       { id: '2', name: 'Geometry', cards: 38, completed: 38 },
@@ -20,9 +20,9 @@ export const MOCK_SUBJECTS = [
     name: 'Physics',
     icon: 'planet',
     iconBackgroundColor: '#FEF3C7',
-    headerColor: '#F59E0B', // amber
+    headerColor: '#F59E0B',
     collections: [
-      { id: '5', name: 'Newton\'s Laws', cards: 30, completed: 25 },
+      { id: '5', name: "Newton's Laws", cards: 30, completed: 25 },
       { id: '6', name: 'Thermodynamics', cards: 42, completed: 10 },
       { id: '7', name: 'Electromagnetism', cards: 55, completed: 0 },
     ],
@@ -32,7 +32,7 @@ export const MOCK_SUBJECTS = [
     name: 'Chemistry',
     icon: 'flask',
     iconBackgroundColor: '#DCFCE7',
-    headerColor: '#10B981', // green
+    headerColor: '#10B981',
     collections: [
       { id: '8', name: 'Periodic Table', cards: 50, completed: 50 },
       { id: '9', name: 'Chemical Reactions', cards: 35, completed: 20 },
@@ -44,7 +44,7 @@ export const MOCK_SUBJECTS = [
     name: 'Biology',
     icon: 'leaf',
     iconBackgroundColor: '#E0E7FF',
-    headerColor: '#8B5CF6', // purple
+    headerColor: '#8B5CF6',
     collections: [
       { id: '11', name: 'Cell Biology', cards: 40, completed: 30 },
       { id: '12', name: 'Genetics', cards: 48, completed: 12 },
@@ -54,7 +54,7 @@ export const MOCK_SUBJECTS = [
 
 // Helper function to get a subject by id
 export const getSubjectById = (id) => {
-  return MOCK_SUBJECTS.find(subject => subject.id === id);
+  return MOCK_SUBJECTS.find((subject) => subject.id === id);
 };
 
 // Helper function to get all collections for a subject


### PR DESCRIPTION
- Replace manual subject creation with MOCK_SUBJECTS data
- Add navigation to subject collections screen on card press
- Update subject card props to use mock data structure
- Display dynamic collection count per subject
- Update stats to show actual subject count
- Use subject ID for deletion instead of object comparison